### PR TITLE
Use NetworkFirst caching strategy for PWA pages

### DIFF
--- a/apps/pwa/astro.config.mjs
+++ b/apps/pwa/astro.config.mjs
@@ -119,28 +119,9 @@ export default defineConfig({
                 globIgnores: ['**/_worker.js/**/*'],
                 navigateFallback: null,
                 runtimeCaching: [
-                    // @note: In the future where we might benefit from always presenting up-to-date data, we'll use this
-                    // Make sure to remove the "/" routes below
-                    // {
-                    //   urlPattern: ({ url, request }) => {
-                    //     return url.pathname === "/" || url.pathname.endsWith("/");
-                    //   },
-                    //   handler: "NetworkFirst",
-                    //   options: {
-                    //     cacheName: "ssr-homepage-cache",
-                    //     expiration: {
-                    //       maxAgeSeconds: 60 * 60 * 1, // 1 hours
-                    //     },
-                    //     cacheableResponse: {
-                    //       statuses: [0, 200],
-                    //     },
-                    //     networkTimeoutSeconds: 3, // Timeout if network is slow
-                    //   },
-                    // },
                     {
                         urlPattern: ({ url }) => {
                             return (
-                                // Remove these routes when you're implementing "NetworkFirst" in the future
                                 url.pathname === '/' ||
                                 url.pathname.endsWith('/') ||
                                 //
@@ -149,12 +130,13 @@ export default defineConfig({
                                 url.pathname.startsWith('/events/')
                             );
                         },
-                        handler: 'StaleWhileRevalidate',
+                        handler: 'NetworkFirst',
                         options: {
                             cacheName: 'ssr-pages-cache',
                             cacheableResponse: {
                                 statuses: [0, 200],
                             },
+                            networkTimeoutSeconds: 3,
                         },
                     },
                     {


### PR DESCRIPTION
Resolves #16 

### Changes

- Change caching strategy for pages from `StaleWhileRevalidate` to `NetworkFirst` so that they are always referencing the latest stylesheet

### Testing

1. Build and serve the production `pwa` app
    ```bash
    cd apps/pwa
    pnpm build
    pnpm serve
    ```
1. Open the app in your browser http://localhost:8788/
2. Visit the calendar page by clicking the **Calendar** link in the top navigation
3. Open your browser's DevTools, in the **Application** tab select **Cache storage** in the sidebar
4. Select the `ssr-pages-cache` storage and confirm that the calendar page has been cached as the `/calendar` route
5. Select the `workbox-precache-v2` storage and confirm that the CSS file for the calendar page has been precached, it will look like `/_astro/calendar.<some-hash>.css`
6. Return to the home page
7. Make a change in the calendar page styles that will cause it to generate a new hash for its CSS file. For example, add the `py-0` class in [this line](https://github.com/dorelljames/cebby/blob/main/apps/pwa/src/pages/calendar.astro#L148)
8. Rebuild and serve the production `pwa` app again following the commands in step 1
9. Reload the cebby home page and wait for the "new content available" alert to show up
10. In DevTools, go to the **Application** tab and select **Cache storage** in the sidebar
11. Select the `workbox-precache-v2` storage and confirm that a new version of the CSS file for the calendar page has been precached. There should now be two paths in there that look like `/_astro/calendar.<some-hash>.css`
12. Click the **Reload** button in the "new content available" alert
13. Confirm that only the latest version of the `/_astro/calendar.<some-hash>.css` file remains in the `workbox-precache-v2` storage
14. Visit the calendar page again, confirm that the page loads with the correct styles from the latest version of the CSS file
15. In the DevTools **Network** tab, enable offline mode from the network throttling dropdown and reload the page
16. Confirm that the calendar page still loads properly even when in offline mode