### PR TITLE
Clear ssr-pages-cache storage on new service worker versions

### DIFF
--- a/apps/pwa/src/components/pwa.ts
+++ b/apps/pwa/src/components/pwa.ts
@@ -58,8 +58,17 @@ window.addEventListener('load', () => {
             pwaToastMessage.innerHTML = 'New content available, click on reload button to update';
             showPwaToast(false);
         },
-        onRegisteredSW(swScriptUrl) {
-            console.log('SW registered: ', swScriptUrl);
+        async onRegisteredSW(swScriptUrl, registration) {
+            console.log('Service worker registered: ', swScriptUrl);
+            if (registration?.waiting) {
+                console.log('New service worker version, deleting "ssr-pages-cache" cache storage...');
+                try {
+                    await caches.delete('ssr-pages-cache');
+                    console.log('Deleted "ssr-pages-cache" cache storage');
+                } catch (error) {
+                    console.error('Failed to delete "ssr-pages-cache" cache storage: ', error);
+                }
+            }
         },
         onRegisterError(error) {
             console.error('SW registration error', error);


### PR DESCRIPTION
Resolves #16 

### Changes

- Delete the `ssr-pages-cache` cache storage whenever a new service worker version is registered and waiting to be activated, so that it will get repopulated with the latest version of the pages that's referencing the latest assets and contains the latest data after the latest build

### Testing

1. Build and serve the production `pwa` app
    ```bash
    cd apps/pwa
    pnpm build
    pnpm serve
    ```
1. Open the app in your browser http://localhost:8788/
2. Visit the calendar page by clicking the **Calendar** link in the top navigation
3. Open your browser's DevTools, in the **Application** tab select **Cache storage** in the sidebar
4. Select the `ssr-pages-cache` storage and confirm that the calendar page has been cached as the `/calendar` route
5. Return to the home page
6. Make a change in the calendar page styles that will cause it to generate a new hash for its CSS file. For example, add the `py-0` class in [this line](https://github.com/dorelljames/cebby/blob/main/apps/pwa/src/pages/calendar.astro#L148)
7. Rebuild and serve the production `pwa` app again following the commands in step 1
8. Reload the cebby home page and wait for the "new content available" alert to show up, click on the **Reload** button in the alert
9. In DevTools, go to the **Application** tab and select **Cache storage** in the sidebar, confirm that either there is no more `ssr-pages-cache` cache storage or it only cached the `/` route. The `/calendar` route should not be present in the cache storage
10. Visit the calendar page again, confirm that the page loads with the correct styles from the latest version of the CSS file
11. In the DevTools **Network** tab, enable offline mode from the network throttling dropdown and reload the page
12. Confirm that the calendar page still loads properly even when in offline mode