### PR TITLE
Highlight date only if it is the date today

### DIFF
--- a/apps/pwa/src/pages/calendar.astro
+++ b/apps/pwa/src/pages/calendar.astro
@@ -225,7 +225,7 @@ function getAllEventsGroupedByDate() {
                                 }
 
                                 const dayEvents = getEventsForDay(day);
-                                const isToday = isSameDay(day, selectedDate);
+                                const isToday = isDateToday(day);
                                 const dayNumber = format(day, 'd');
                                 const hasEvents = dayEvents.length > 0;
                                 const isPast = day < new Date(new Date().setHours(0, 0, 0, 0));


### PR DESCRIPTION
### Changes

Currently when you go to the calendar page, it opens the current month by default and highlights the current date. When you go to a previous or future month, the calendar for that month is displayed but the same day in that month is also highlighted even if that's not the date today.

This change fixes how the date today is determined in the calendar view to only highlight the date if it is the date today.

### Testing

- Navigate to the calendar page by clicking on the link in the top banner, confirm that it opens to the current month and the current date is highlighted
- Navigate to a previous or next month, confirm that the there are no dates highlighted